### PR TITLE
security: add permissions blocks to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: /opt/claude-web
@@ -242,4 +245,3 @@ jobs:
             echo "::error::Claude CLI does not support --permission-mode flag"
             exit 1
           fi
-

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,6 +20,9 @@ on:
     # Weekly scan: Sunday at 02:00 UTC
     - cron: "0 2 * * 0"
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: /opt/claude-web


### PR DESCRIPTION
## Summary
- Add explicit permissions blocks to workflow files missing them
- Follows principle of least privilege
- Resolves GitHub Code Security "Workflow does not contain permissions" alerts

## Test plan
- [ ] CI passes on this PR

Generated with Claude Code